### PR TITLE
Properly trap signals like sigterm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ RUN apt-get -y update  && apt-get install -y netcat
 ADD root/ /
 
 EXPOSE 1433
-CMD /docker-entrypoint.sh
+CMD ["/docker-entrypoint.sh"]

--- a/root/docker-entrypoint.sh
+++ b/root/docker-entrypoint.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
+/setup-db-for-moodle.sh &
 
-/setup-db-for-moodle.sh& /opt/mssql/bin/sqlservr
+exec /opt/mssql/bin/sqlservr
+


### PR DESCRIPTION
Fixes #4.

Now logs properly tells about the shutdown:
```
...
[moodle-db-mssql] Setup complete.
2017-07-26 10:19:11.10 spid5s      Always On: The availability replica manager is going offline because SQL Server is shutting down. This is an informational message only. No user action is required.
2017-07-26 10:19:11.10 spid5s      SQL Server is terminating in response to a 'stop' request from Service Control Manager. This is an informational message only. No user action is required.
2017-07-26 10:19:11.20 spid24s     Service Broker manager has shut down.
2017-07-26 10:19:11.23 spid5s      SQL Trace was stopped due to server shutdown. Trace ID = '1'. This is an informational message only; no user action is required.
```
at the price of a zombie :smile::
```
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  2.5  0.4  80212 17560 ?        Ssl  10:18   0:00 /opt/mssql/bin/
root         6  0.0  0.0      0     0 ?        Z    10:18   0:00 [bash] <defunct
root        11 29.1 17.6 2939280 686088 ?      Sl   10:18   0:04 /opt/mssql/bin/
root       167  0.0  0.0  34416  1448 pts/0    Rs+  10:18   0:00 ps uax
```


