### PR TITLE
Revert "Update to rc1"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/mssql-server-linux:rc1
+FROM microsoft/mssql-server-linux:ctp2-1
 
 RUN apt-get -y update  && apt-get install -y netcat
 


### PR DESCRIPTION
RC1 is currently very unstable.
See https://github.com/Microsoft/mssql-docker/issues/126 for info.

This reverts commit dfb499a75de9474732af72bbbd102dd676c2aacf.