### PR TITLE
Bump to SQL*Server 15 (2019)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM microsoft/mssql-server-linux:2017-GA
+FROM mcr.microsoft.com/mssql/server:2019-latest
 
-RUN apt-get -y update  && apt-get install -y netcat
+USER root
+RUN apt-get -y update && apt-get install -y netcat
 
 ADD root/ /
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # moodle-db-mssql: Microsoft SQL Server for Moodle
 [![Build Status](https://travis-ci.org/moodlehq/moodle-db-mssql.svg?branch=master)](https://travis-ci.org/moodlehq/moodle-db-mssql)
 
-A Microsoft SQL Server for Linux instance configured for Moodle development. Based on [microsoft/mssql-server-linux](https://hub.docker.com/r/microsoft/mssql-server-linux/)
+A Microsoft SQL Server for Linux instance configured for Moodle development. Based on [mcr.microsoft.com/mssql/server](https://hub.docker.com/_/microsoft-mssql-server)
 
 # Example usage
 


### PR DESCRIPTION
**IMPORTANT:** DON'T merge this yet! Complete PHPUnit execution is becoming stuck @ 36%, this is being investigated (see following comments).

<hr/>
Using the 2019-latest tag. Changed to new Microsoft docker sources.

Main advantage being > 1Gb less of RAM needed. And apparently, quicker execution too (although this is a non-scientific-backed feeling only).

Some other tags have been also generated (to have them at hand if
needed:

- 2017-latest : the latest available build of SQL*Server 14 (2017).
- 2019-GA : the very first version available of  SQL*Server 15 (2019).
- latest : current 2019-latest (will be the used by default from now on).

Side note... the images are, right now, being sent to dockerhub (super-slowly, not sure why)... so we can start using the new "latest" (2019-latest) ASAP.

Will prune workers once everything is uploaded.

Note that database tests completed here perfectly ok (using moodle-docker):

````
$ bin/moodle-docker-compose exec webserver vendor/bin/phpunit --testsuite 'core_ddl_testsuite,core_dml_testsuite'
Moodle 3.9dev (Build: 20191205), 8cf4c97217230e74e57e41f24e8afbbc8393eb79
Php: 7.2.21, sqlsrv: 15.00.2070, OS: Linux 4.19.76-linuxkit x86_64
PHPUnit 7.5.17 by Sebastian Bergmann and contributors.

...............................................................  63 / 185 ( 34%)
............................................................... 126 / 185 ( 68%)
.........S..................SSSSSSSSS......................     185 / 185 (100%)

Time: 43.34 seconds, Memory: 84.25 MB

OK, but incomplete, skipped, or risky tests!
Tests: 185, Assertions: 1639, Skipped: 10.
````