### PR TITLE
Bump to SQL*Server 14 (2017) CU18 (ubuntu 16.04)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM microsoft/mssql-server-linux:2017-GA
+FROM mcr.microsoft.com/mssql/server:2017-CU18-ubuntu-16.04
 
-RUN apt-get -y update  && apt-get install -y netcat
+RUN apt-get -y update && apt-get install -y netcat
 
 ADD root/ /
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # moodle-db-mssql: Microsoft SQL Server for Moodle
 [![Build Status](https://travis-ci.org/moodlehq/moodle-db-mssql.svg?branch=master)](https://travis-ci.org/moodlehq/moodle-db-mssql)
 
-A Microsoft SQL Server for Linux instance configured for Moodle development. Based on [microsoft/mssql-server-linux](https://hub.docker.com/r/microsoft/mssql-server-linux/)
+A Microsoft SQL Server for Linux instance configured for Moodle development. Based on [mcr.microsoft.com/mssql/server](https://hub.docker.com/_/microsoft-mssql-server)
 
 # Example usage
 


### PR DESCRIPTION
Changed to new Microsoft docker sources

I'm running a complete phpunit run locally. Already have confirmed that the locking problems with 2019 are not present with this version. Also that memory usage becomes highly down, that was the main reason to bump.

Will share the results here once they finish.