### PR TITLE
wait: Use sqlcmd to detect when the database is actually serving

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM mcr.microsoft.com/mssql/server:2017-CU20-ubuntu-16.04
 
-RUN apt-get -y update && apt-get install -y netcat
-
 ADD root/ /
 
 EXPOSE 1433

--- a/root/wait-for-mssql-to-come-up.sh
+++ b/root/wait-for-mssql-to-come-up.sh
@@ -3,15 +3,16 @@
 set -e
 
 i=0
-# Wait for the SQL Server to come up.
-until nc -z -w2 127.0.0.1 1433
+until /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$SA_PASSWORD" -d master -l 1 -Q "SELECT 1" > /dev/null 2>&1
 do
-    echo "[moodle-db-mssql] Waiting 5s for mssql to come up setup"
-    sleep 5
+    echo "[moodle-db-mssql] Waiting for SQL to accept connections"
+    sleep 1
+
     i=$((i+1))
     if [ $i -gt 60 ]; then
-        echo "[moodle-db-mssql] timed out waiting for server to come up after 5 mins"
+        echo "[moodle-db-mssql] timed out waiting for server to accept connections"
         exit 1;
     fi
 done
+
 echo "[moodle-db-mssql] SQL Server UP"


### PR DESCRIPTION
We have encountered situations where it is possible for the port to be
open, but the system is not ready to actually serve connections.

This change switches from netcat to using `sqlcmd` to execute an actual
command against the database and quit instead, ensuring that the
database is actually ready to serve connections.