### PR TITLE
Bump to SQL*Server 14 (2017) CU24 (ubuntu 16.04)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/mssql/server:2017-CU21-ubuntu-16.04
+FROM mcr.microsoft.com/mssql/server:2017-CU24-ubuntu-16.04
 
 ADD root/ /
 


### PR DESCRIPTION
Some notes:

- Originally this also included some changes to Travis to be able to verify that the `-e MSSQL_PID=Express'` edition was working ok and perform some runs @ testing infrastructure. I did them and got ~ 100% the same results (memory, cpu, io, total run time...) with current Developer (Enterprise) edition and with the Express one. So no worth changing to Express.
- Note these images have been already pushed manually to dockerhub, so they are being used since a couple of days agon.