### PR TITLE
Disable aggressive flushing (ok for testing)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,24 @@
 FROM mcr.microsoft.com/mssql/server:2017-CU24-ubuntu-16.04
 
+
+# Starting with SQL*Server 2017-CU6, by default, flushing became
+# more aggresive, in order to guarantee consistency under power
+# failures and similar situations. Explanations available:
+#   https://bobsql.com/sql-server-on-linux-forced-unit-access-fua-internals/
+# But it came with some severe performance problems on write operations
+# that haven't been fixed yet (making it some env variable for the images
+# or whatever). See https://github.com/microsoft/mssql-docker/issues/355 .
+#
+# So here, we are just disabling such an aggressive flushing to make it
+# work like was before CU6. We don't need it for testing purposes and
+# differences, tested under standard conditions are big enough:
+# Complete phpunit runs:
+# - 2017-CU24: 1h 51m
+# - 2017-CU24 + this patch: 1h 10m
+RUN /opt/mssql/bin/mssql-conf traceflag 3979 on && \
+        /opt/mssql/bin/mssql-conf set control.alternatewritethrough 0 && \
+        /opt/mssql/bin/mssql-conf set control.writethrough 0
+
 ADD root/ /
 
 EXPOSE 1433

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/mssql/server:2017-CU21-ubuntu-16.04
+FROM mcr.microsoft.com/mssql/server:2017-CU24-ubuntu-16.04
 
 ADD root/ /
 


### PR DESCRIPTION
This has to be merged after #16 !

Link: https://github.com/microsoft/mssql-docker/issues/355
    
Latest sqlsrv builds have become way slower. Looking for issues
the linked one above could be a reason. It seems that in CU6,
in order to guarantee data integrity (only for some OSs) they
enabled a more aggressive/often flushing to disk. And that
killed write performance.
    
In the same issue there are comments about how to disable such
an aggressive flushing, that is perfectly valid for testing.
    
Hence, doing it and running some unit tests to see if that
gives us some better execution times...

Some runs (same/standard execution conditions):
- [2017-CU24](https://ci.moodle.org/view/Testing/job/DEV.02%20-%20Developer-requested%20PHPUnit/4673/): 1h 51m
- [2017-CU24 + this patch](https://ci.moodle.org/view/Testing/job/DEV.02%20-%20Developer-requested%20PHPUnit/4679/): 1h 10m