### PR TITLE
Bump to SQL*Server 15 (2019) CU32 (ubuntu 20.04)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run tests
         run: |
           # Verify we have a working SQL server.
-          docker exec test0 /opt/mssql-tools/bin/sqlcmd -U sa -P m@0dl3ing -Q "SELECT @@VERSION" | grep "Microsoft SQL Server"
+          docker exec test0 /opt/mssql-tools18/bin/sqlcmd -C -U sa -P m@0dl3ing -Q "SELECT @@VERSION" | grep "Microsoft SQL Server"
 
       - name: Output logs
         if: ${{ failure() }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/mssql/server:2019-CU22-ubuntu-20.04
+FROM mcr.microsoft.com/mssql/server:2019-CU32-ubuntu-20.04
 
 
 # Starting with SQL*Server 2017-CU6, by default, flushing became
@@ -17,10 +17,13 @@ FROM mcr.microsoft.com/mssql/server:2019-CU22-ubuntu-20.04
 # Complete phpunit runs:
 # - 2019-CU18: 4h 38m
 # - 2019-CU18 + this patch: 1h 33m
+#
+# Besides, disable SQL Server forcing all connections to be encrypted.
 USER root
 RUN /opt/mssql/bin/mssql-conf traceflag 3979 on && \
         /opt/mssql/bin/mssql-conf set control.alternatewritethrough 0 && \
-        /opt/mssql/bin/mssql-conf set control.writethrough 0
+        /opt/mssql/bin/mssql-conf set control.writethrough 0 && \
+        /opt/mssql/bin/mssql-conf set network.forceencryption 0
 
 ADD root/ /
 

--- a/root/setup-db-for-moodle.sh
+++ b/root/setup-db-for-moodle.sh
@@ -5,5 +5,5 @@ set -e
 ./wait-for-mssql-to-come-up.sh
 
 echo "[moodle-db-mssql] Setting up Moodle data"
-/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P $SA_PASSWORD -d master -i setup.sql
+/opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P $SA_PASSWORD -d master -i setup.sql
 echo "[moodle-db-mssql] Setup complete."

--- a/root/wait-for-mssql-to-come-up.sh
+++ b/root/wait-for-mssql-to-come-up.sh
@@ -3,7 +3,7 @@
 set -e
 
 i=0
-until /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$SA_PASSWORD" -d master -l 1 -Q "SELECT 1" > /dev/null 2>&1
+until /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P "$SA_PASSWORD" -d master -l 1 -Q "SELECT 1" > /dev/null 2>&1
 do
     echo "[moodle-db-mssql] Waiting for SQL to accept connections"
     sleep 1


### PR DESCRIPTION
Bump CU to avoid startup crash on Ubuntu 24.04: CU26+ will start fine on both Ubuntu 22.04 and Ubuntu 24.04.

Changes due to latest SQL*Server 15 (2019) CU32:
1. The path `/opt/mssql-tools/bin/sqlcmd` changed to `/opt/mssql-tools18/bin/sqlcmd`.
2. Adds `-C` to trust the server certificate.
3. Disable SQL Server forcing all connections to be encrypted.

Refs:
- https://learn.microsoft.com/en-us/sql/linux/sql-server-linux-configure-mssql-conf?view=sql-server-ver15#specify-tls-settings

Fixes https://github.com/moodlehq/moodle-db-mssql/issues/21.